### PR TITLE
Improve and extend `faq` extension with data versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - `faq` has been extended and improved:
-  - Allows for aliases to be add/removed from FAQs
-  - Tracks creation/modification dates for each entries
-  - Tracks the number of look-ups/hits for each entry
-  - Sorts the list of FAQs by hits -> name
-  - Includes more sub-commands for managing FAQ entries
+  - FAQs can be created and updated directly from existing messages
+  - FAQs can be assigned any number of aliases
+  - FAQs remember when they were created and last updated
+  - FAQs keep track of how many times they're used (hits)
+  - The list of FAQs is sorted by hits -> name
+  - More sub-commands for managing FAQs directly
 - Updated to commanderbot-lib version 0.5.0
 
 ## [0.3.0] - 2020-09-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- `faq` has been extended and improved:
+  - Allows for aliases to be add/removed from FAQs
+  - Tracks creation/modification dates for each entries
+  - Tracks the number of look-ups/hits for each entry
+  - Sorts the list of FAQs by hits -> name
+  - Includes more sub-commands for managing FAQ entries
 - Updated to commanderbot-lib version 0.5.0
 
 ## [0.3.0] - 2020-09-30

--- a/commanderbot_ext/faq/faq_cache.py
+++ b/commanderbot_ext/faq/faq_cache.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Dict, List
+from typing import Dict, Set
 
 from commanderbot_lib.types import GuildID
 
@@ -10,7 +10,7 @@ class FaqEntry:
     name: str
     content: str
     message_link: str
-    aliases: List[str]
+    aliases: Set[str]
     added_on: datetime
     last_modified_on: datetime
     hits: int
@@ -52,7 +52,7 @@ class FaqEntry:
             name=name,
             content=content,
             message_link=message_link,
-            aliases=aliases,
+            aliases=set(aliases),
             added_on=added_on,
             last_modified_on=last_modified_on,
             hits=hits,
@@ -62,7 +62,7 @@ class FaqEntry:
         return {
             "content": self.content,
             "message_link": self.message_link,
-            "aliases": self.aliases,
+            "aliases": list(self.aliases),
             "added_on": self.added_on.isoformat(),
             "last_modified_on": self.last_modified_on.isoformat(),
             "hits": self.hits,

--- a/commanderbot_ext/faq/faq_cache.py
+++ b/commanderbot_ext/faq/faq_cache.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
-from typing import Dict
+from datetime import datetime
+from typing import Dict, List
 
 from commanderbot_lib.types import GuildID
 
@@ -9,21 +10,63 @@ class FaqEntry:
     name: str
     content: str
     message_link: str
+    aliases: List[str]
+    added_on: datetime
+    last_modified_on: datetime
+    hits: int
 
     @staticmethod
     async def deserialize(data: dict, name: str) -> "FaqEntry":
         if not isinstance(data, dict):
             raise ValueError(f"Invalid FAQ data: {type(data)}")
-        content: str = data.get("content")
-        if not isinstance(content, str):
-            raise ValueError(f"Invalid FAQ content: {type(content)}")
-        message_link = data.get("message_link")
-        if not (message_link is None or isinstance(message_link, str)):
-            raise ValueError(f"Invalid FAQ message link: {type(message_link)}")
-        return FaqEntry(name=name, content=content, message_link=message_link)
+
+        # content
+        content: str = data["content"]
+        assert isinstance(content, str)
+
+        # message_link
+        message_link = data["message_link"]
+        assert message_link is None or isinstance(message_link, str)
+
+        # aliases
+        aliases = data["aliases"]
+        assert isinstance(aliases, list)
+        for alias in aliases:
+            assert isinstance(alias, str)
+
+        # added_on
+        raw_added_on = data["added_on"]
+        assert isinstance(raw_added_on, str)
+        added_on = datetime.fromisoformat(raw_added_on)
+
+        # last_modified_on
+        raw_last_modified_on = data["last_modified_on"]
+        assert isinstance(raw_last_modified_on, str)
+        last_modified_on = datetime.fromisoformat(raw_last_modified_on)
+
+        # hits
+        hits = data["hits"]
+        assert isinstance(hits, int)
+
+        return FaqEntry(
+            name=name,
+            content=content,
+            message_link=message_link,
+            aliases=aliases,
+            added_on=added_on,
+            last_modified_on=last_modified_on,
+            hits=hits,
+        )
 
     def serialize(self) -> dict:
-        return {"content": self.content, "message_link": self.message_link}
+        return {
+            "content": self.content,
+            "message_link": self.message_link,
+            "aliases": self.aliases,
+            "added_on": self.added_on.isoformat(),
+            "last_modified_on": self.last_modified_on.isoformat(),
+            "hits": self.hits,
+        }
 
 
 @dataclass

--- a/commanderbot_ext/faq/faq_cache.py
+++ b/commanderbot_ext/faq/faq_cache.py
@@ -12,7 +12,7 @@ class FaqEntry:
     message_link: str
     aliases: Set[str]
     added_on: datetime
-    last_modified_on: datetime
+    updated_on: datetime
     hits: int
 
     @staticmethod
@@ -39,10 +39,10 @@ class FaqEntry:
         assert isinstance(raw_added_on, str)
         added_on = datetime.fromisoformat(raw_added_on)
 
-        # last_modified_on
-        raw_last_modified_on = data["last_modified_on"]
-        assert isinstance(raw_last_modified_on, str)
-        last_modified_on = datetime.fromisoformat(raw_last_modified_on)
+        # updated_on
+        raw_updated_on = data["updated_on"]
+        assert isinstance(raw_updated_on, str)
+        updated_on = datetime.fromisoformat(raw_updated_on)
 
         # hits
         hits = data["hits"]
@@ -54,7 +54,7 @@ class FaqEntry:
             message_link=message_link,
             aliases=set(aliases),
             added_on=added_on,
-            last_modified_on=last_modified_on,
+            updated_on=updated_on,
             hits=hits,
         )
 
@@ -64,7 +64,7 @@ class FaqEntry:
             "message_link": self.message_link,
             "aliases": list(self.aliases),
             "added_on": self.added_on.isoformat(),
-            "last_modified_on": self.last_modified_on.isoformat(),
+            "updated_on": self.updated_on.isoformat(),
             "hits": self.hits,
         }
 

--- a/commanderbot_ext/faq/faq_cog.py
+++ b/commanderbot_ext/faq/faq_cog.py
@@ -6,7 +6,6 @@ from commanderbot_lib import checks
 from commanderbot_lib.logging import Logger, get_clogger
 from discord import Message
 from discord.ext.commands import Bot, Cog, Context, group
-from discord.ext.commands.help import HelpCommand
 
 
 # TODO Try to cut-down on the amount of boilerplate by sub-classing `Cog`. #refactor
@@ -15,7 +14,7 @@ class FaqCog(Cog, name="commanderbot_ext.faq"):
         self.bot: Bot = bot
         self.options: FaqOptions = FaqOptions(**options)
         self._log: Logger = get_clogger(self)
-        self._state: FaqState = None
+        self._state: Optional[FaqState] = None
 
     @property
     def state(self) -> FaqState:

--- a/commanderbot_ext/faq/faq_cog.py
+++ b/commanderbot_ext/faq/faq_cog.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from commanderbot_ext.faq.faq_options import FaqOptions
 from commanderbot_ext.faq.faq_state import FaqState
 from commanderbot_lib import checks
@@ -46,15 +48,46 @@ class FaqCog(Cog, name="commanderbot_ext.faq"):
         await self.state.list_faqs(ctx)
 
     @cmd_faq.command(name="show")
-    async def cmd_faq_show(self, ctx: Context, *, name: str):
-        await self.state.show_faq(ctx, name)
+    async def cmd_faq_show(self, ctx: Context, faq_name: str):
+        await self.state.show_faq(ctx, faq_name)
 
-    @cmd_faq.command(name="add")
+    @cmd_faq.command(name="details")
+    async def cmd_faq_details(self, ctx: Context, faq_name: str):
+        await self.state.show_faq_details(ctx, faq_name)
+
+    @cmd_faq.group(name="add")
     @checks.is_administrator()
-    async def cmd_faq_add(self, ctx: Context, message: Message, *, name: str):
-        await self.state.add_faq(ctx, name, message)
+    async def cmd_faq_add(self, ctx: Context):
+        if not ctx.invoked_subcommand:
+            await ctx.send_help(self.cmd_faq_add)
+
+    @cmd_faq_add.command(name="message")
+    @checks.is_administrator()
+    async def cmd_faq_add_message(self, ctx: Context, faq_name: str, message: Message):
+        await self.state.add_faq(ctx, faq_name, message, message.content)
+
+    @cmd_faq_add.command(name="content")
+    @checks.is_administrator()
+    async def cmd_faq_add_content(self, ctx: Context, faq_name: str, *, content: str):
+        await self.state.add_faq(ctx, faq_name, ctx.message, content)
 
     @cmd_faq.command(name="remove")
     @checks.is_administrator()
-    async def cmd_faq_remove(self, ctx: Context, *, name: str):
-        await self.state.remove_faq(ctx, name)
+    async def cmd_faq_remove(self, ctx: Context, faq_name: str):
+        await self.state.remove_faq(ctx, faq_name)
+
+    @cmd_faq.group(name="alias")
+    @checks.is_administrator()
+    async def cmd_faq_alias(self, ctx: Context):
+        if not ctx.invoked_subcommand:
+            await ctx.send_help(self.cmd_faq_alias)
+
+    @cmd_faq_alias.command(name="add")
+    @checks.is_administrator()
+    async def cmd_faq_alias_add(self, ctx: Context, faq_name: str, alias_to_add: str):
+        await self.state.add_alias(ctx, faq_name, alias_to_add)
+
+    @cmd_faq_alias.command(name="remove")
+    @checks.is_administrator()
+    async def cmd_faq_alias_remove(self, ctx: Context, faq_name: str, alias_to_remove: str):
+        await self.state.remove_alias(ctx, faq_name, alias_to_remove)

--- a/commanderbot_ext/faq/faq_cog.py
+++ b/commanderbot_ext/faq/faq_cog.py
@@ -30,6 +30,10 @@ class FaqCog(Cog, name="commanderbot_ext.faq"):
             self._state = FaqState(self.bot, self, self.options)
             await self._state.async_init()
         await self.state.on_ready()
+        # Print a brief log of how many FAQs are loaded.
+        total_faqs = self.state.count_total_faqs
+        total_guilds = len(list(self.state.available_guild_states))
+        self._log.info(f"Loaded {total_faqs} total FAQs across {total_guilds} guilds.")
 
     @Cog.listener()
     async def on_message(self, message: Message):

--- a/commanderbot_ext/faq/faq_cog.py
+++ b/commanderbot_ext/faq/faq_cog.py
@@ -5,7 +5,7 @@ from commanderbot_ext.faq.faq_state import FaqState
 from commanderbot_lib import checks
 from commanderbot_lib.logging import Logger, get_clogger
 from discord import Message
-from discord.ext.commands import Bot, Cog, Context, group
+from discord.ext.commands import Bot, Cog, Context, command, group
 
 
 # TODO Try to cut-down on the amount of boilerplate by sub-classing `Cog`. #refactor
@@ -36,6 +36,10 @@ class FaqCog(Cog, name="commanderbot_ext.faq"):
         await self.state.on_message(message)
 
     # @@ COMMANDS
+
+    @command(name="faqs")
+    async def cmd_faqs(self, ctx: Context):
+        await self.state.list_faqs(ctx)
 
     @group(name="faq")
     async def cmd_faq(self, ctx: Context):

--- a/commanderbot_ext/faq/faq_cog.py
+++ b/commanderbot_ext/faq/faq_cog.py
@@ -30,10 +30,6 @@ class FaqCog(Cog, name="commanderbot_ext.faq"):
             self._state = FaqState(self.bot, self, self.options)
             await self._state.async_init()
         await self.state.on_ready()
-        # Print a brief log of how many FAQs are loaded.
-        total_faqs = self.state.count_total_faqs
-        total_guilds = len(list(self.state.available_guild_states))
-        self._log.info(f"Loaded {total_faqs} total FAQs across {total_guilds} guilds.")
 
     @Cog.listener()
     async def on_message(self, message: Message):

--- a/commanderbot_ext/faq/faq_cog.py
+++ b/commanderbot_ext/faq/faq_cog.py
@@ -47,12 +47,12 @@ class FaqCog(Cog, name="commanderbot_ext.faq"):
         await self.state.list_faqs(ctx)
 
     @cmd_faq.command(name="show")
-    async def cmd_faq_show(self, ctx: Context, faq_name: str):
-        await self.state.show_faq(ctx, faq_name)
+    async def cmd_faq_show(self, ctx: Context, faq_query: str):
+        await self.state.show_faq(ctx, faq_query)
 
     @cmd_faq.command(name="details")
-    async def cmd_faq_details(self, ctx: Context, faq_name: str):
-        await self.state.show_faq_details(ctx, faq_name)
+    async def cmd_faq_details(self, ctx: Context, faq_query: str):
+        await self.state.show_faq_details(ctx, faq_query)
 
     @cmd_faq.group(name="add")
     @checks.is_administrator()

--- a/commanderbot_ext/faq/faq_cog.py
+++ b/commanderbot_ext/faq/faq_cog.py
@@ -58,6 +58,8 @@ class FaqCog(Cog, name="commanderbot_ext.faq"):
     async def cmd_faq_details(self, ctx: Context, faq_query: str):
         await self.state.show_faq_details(ctx, faq_query)
 
+    # @@ faq add
+
     @cmd_faq.group(name="add")
     @checks.is_administrator()
     async def cmd_faq_add(self, ctx: Context):
@@ -74,10 +76,32 @@ class FaqCog(Cog, name="commanderbot_ext.faq"):
     async def cmd_faq_add_content(self, ctx: Context, faq_name: str, *, content: str):
         await self.state.add_faq(ctx, faq_name, ctx.message, content)
 
+    # @@ faq remove
+
     @cmd_faq.command(name="remove")
     @checks.is_administrator()
     async def cmd_faq_remove(self, ctx: Context, faq_name: str):
         await self.state.remove_faq(ctx, faq_name)
+
+    # @@ faq update
+
+    @cmd_faq.group(name="update")
+    @checks.is_administrator()
+    async def cmd_faq_update(self, ctx: Context):
+        if not ctx.invoked_subcommand:
+            await ctx.send_help(self.cmd_faq_update)
+
+    @cmd_faq_update.command(name="message")
+    @checks.is_administrator()
+    async def cmd_faq_update_message(self, ctx: Context, faq_name: str, message: Message):
+        await self.state.update_faq(ctx, faq_name, message, message.content)
+
+    @cmd_faq_update.command(name="content")
+    @checks.is_administrator()
+    async def cmd_faq_update_content(self, ctx: Context, faq_name: str, *, content: str):
+        await self.state.update_faq(ctx, faq_name, ctx.message, content)
+
+    # @@ faq alias
 
     @cmd_faq.group(name="alias")
     @checks.is_administrator()

--- a/commanderbot_ext/faq/faq_guild_state.py
+++ b/commanderbot_ext/faq/faq_guild_state.py
@@ -9,6 +9,10 @@ from discord.ext.commands import Context
 
 
 class FaqGuildState(CogGuildState[FaqOptions, FaqStore]):
+    @property
+    def count_faqs(self) -> int:
+        return self.store.count_guild_faqs(self.guild) or 0
+
     async def list_faqs(self, ctx: Context):
         if entries := await self.store.iter_guild_faqs(self.guild):
             # Sort entries by hits -> name.

--- a/commanderbot_ext/faq/faq_guild_state.py
+++ b/commanderbot_ext/faq/faq_guild_state.py
@@ -20,7 +20,8 @@ class FaqGuildState(CogGuildState[FaqOptions, FaqStore]):
             await ctx.send(f"No FAQs available")
 
     async def show_faq(self, ctx: Context, name: str):
-        if entry := await self.store.get_guild_faq(self.guild, name, hit=True):
+        if entry := await self.store.get_guild_faq(self.guild, name):
+            await self.store.hit_entry(entry)
             await ctx.send(entry.content)
         else:
             await ctx.send(f"No such FAQ `{name}`")

--- a/commanderbot_ext/faq/faq_guild_state.py
+++ b/commanderbot_ext/faq/faq_guild_state.py
@@ -21,7 +21,7 @@ class FaqGuildState(CogGuildState[FaqOptions, FaqStore]):
 
     async def show_faq(self, ctx: Context, name: str):
         if entry := await self.store.get_guild_faq(self.guild, name):
-            await self.store.increment_entry_hits(entry)
+            await self.store.increment_faq_hits(entry)
             await ctx.send(entry.content)
         else:
             await ctx.send(f"No such FAQ `{name}`")
@@ -71,15 +71,19 @@ class FaqGuildState(CogGuildState[FaqOptions, FaqStore]):
 
     async def add_alias(self, ctx: Context, faq_name: str, alias: str):
         if entry := await self.store.get_guild_faq(self.guild, faq_name):
-            await self.store.add_alias_to_entry(entry, alias)
-            await ctx.send(f"Added alias `{alias}` to FAQ `{faq_name}`")
+            if await self.store.add_alias_to_faq(entry, alias):
+                await ctx.send(f"Added alias `{alias}` to FAQ `{faq_name}`")
+            else:
+                await ctx.send(f"FAQ `{faq_name}` already has alias `{alias}`")
         else:
             await ctx.send(f"No such FAQ `{faq_name}`")
 
     async def remove_alias(self, ctx: Context, faq_name: str, alias: str):
         if entry := await self.store.get_guild_faq(self.guild, faq_name):
-            await self.store.remove_alias_from_entry(entry, alias)
-            await ctx.send(f"Removed alias `{alias}` from FAQ `{faq_name}`")
+            if await self.store.remove_alias_from_faq(entry, alias):
+                await ctx.send(f"Removed alias `{alias}` from FAQ `{faq_name}`")
+            else:
+                await ctx.send(f"FAQ `{faq_name}` does not have alias {alias}")
         else:
             await ctx.send(f"No such FAQ `{faq_name}`")
 

--- a/commanderbot_ext/faq/faq_guild_state.py
+++ b/commanderbot_ext/faq/faq_guild_state.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from commanderbot_ext.faq.faq_cache import FaqEntry
 from commanderbot_ext.faq.faq_options import FaqOptions
 from commanderbot_ext.faq.faq_store import FaqStore
@@ -17,16 +19,45 @@ class FaqGuildState(CogGuildState[FaqOptions, FaqStore]):
             await ctx.send(f"No FAQs available")
 
     async def show_faq(self, ctx: Context, name: str):
-        if entry := await self.store.get_guild_faq(self.guild, name):
+        if entry := await self.store.get_guild_faq(self.guild, name, hit=True):
             await ctx.send(entry.content)
         else:
             await ctx.send(f"No such FAQ `{name}`")
 
-    async def add_faq(self, ctx: Context, name: str, message: Message):
+    async def show_faq_details(self, ctx: Context, name: str):
+        if entry := await self.store.get_guild_faq(self.guild, name):
+            aliases_str = ", ".join(entry.aliases)
+            added_on_str = entry.added_on.isoformat()
+            last_modified_on_str = entry.last_modified_on.isoformat()
+            lines = [
+                f"<{entry.message_link}>",
+                "```",
+                f"Name:             {entry.name}",
+                f"Aliases:          {aliases_str}",
+                f"Added on:         {added_on_str}",
+                f"Last modified on: {last_modified_on_str}",
+                f"Hits:             {entry.hits}",
+                "```",
+            ]
+            content = "\n".join(lines)
+            await ctx.send(content)
+        else:
+            await ctx.send(f"No such FAQ `{name}`")
+
+    async def add_faq(self, ctx: Context, name: str, message: Message, content: str):
         if await self.store.get_guild_faq(self.guild, name):
             await ctx.send(f"FAQ `{name}` already exists")
         else:
-            faq_entry = FaqEntry(name=name, content=message.content, message_link=message.jump_url)
+            now = datetime.utcnow()
+            faq_entry = FaqEntry(
+                name=name,
+                content=content,
+                message_link=message.jump_url,
+                aliases=[],
+                added_on=now,
+                last_modified_on=now,
+                hits=0,
+            )
             await self.store.add_guild_faq(self.guild, faq_entry)
             await ctx.send(f"Added FAQ `{name}`")
 
@@ -35,6 +66,14 @@ class FaqGuildState(CogGuildState[FaqOptions, FaqStore]):
             await ctx.send(f"Removed FAQ `{removed_entry.name}`")
         else:
             await ctx.send(f"No such FAQ `{name}`")
+
+    async def add_alias(self, ctx: Context, faq_name: str, alias: str):
+        # IMPL
+        await ctx.send(f"Added alias `{alias}` to FAQ `{faq_name}`")
+
+    async def remove_alias(self, ctx: Context, faq_name: str, alias: str):
+        # IMPL
+        await ctx.send(f"Removed alias `{alias}` from FAQ `{faq_name}`")
 
     # @overrides CogGuildState
     async def on_message(self, message: Message):

--- a/commanderbot_ext/faq/faq_guild_state.py
+++ b/commanderbot_ext/faq/faq_guild_state.py
@@ -70,6 +70,13 @@ class FaqGuildState(CogGuildState[FaqOptions, FaqStore]):
         else:
             await ctx.send(f"No FAQ named `{faq_name}`")
 
+    async def update_faq(self, ctx: Context, faq_name: str, message: Message, content: str):
+        if faq_entry := await self.store.get_guild_faq_by_name(self.guild, faq_name):
+            await self.store.update_faq(faq_entry, message, content)
+            await ctx.send(f"Updated FAQ named `{faq_name}`")
+        else:
+            await ctx.send(f"No FAQ named `{faq_name}`")
+
     async def add_alias(self, ctx: Context, faq_name: str, faq_alias: str):
         if faq_entry := await self.store.get_guild_faq_by_name(self.guild, faq_name):
             if await self.store.add_alias_to_faq(faq_entry, faq_alias):

--- a/commanderbot_ext/faq/faq_guild_state.py
+++ b/commanderbot_ext/faq/faq_guild_state.py
@@ -21,7 +21,7 @@ class FaqGuildState(CogGuildState[FaqOptions, FaqStore]):
 
     async def show_faq(self, ctx: Context, name: str):
         if entry := await self.store.get_guild_faq(self.guild, name):
-            await self.store.hit_entry(entry)
+            await self.store.increment_entry_hits(entry)
             await ctx.send(entry.content)
         else:
             await ctx.send(f"No such FAQ `{name}`")
@@ -70,12 +70,18 @@ class FaqGuildState(CogGuildState[FaqOptions, FaqStore]):
             await ctx.send(f"No such FAQ `{name}`")
 
     async def add_alias(self, ctx: Context, faq_name: str, alias: str):
-        # IMPL
-        await ctx.send(f"Added alias `{alias}` to FAQ `{faq_name}`")
+        if entry := await self.store.get_guild_faq(self.guild, faq_name):
+            await self.store.add_alias_to_entry(entry, alias)
+            await ctx.send(f"Added alias `{alias}` to FAQ `{faq_name}`")
+        else:
+            await ctx.send(f"No such FAQ `{faq_name}`")
 
     async def remove_alias(self, ctx: Context, faq_name: str, alias: str):
-        # IMPL
-        await ctx.send(f"Removed alias `{alias}` from FAQ `{faq_name}`")
+        if entry := await self.store.get_guild_faq(self.guild, faq_name):
+            await self.store.remove_alias_from_entry(entry, alias)
+            await ctx.send(f"Removed alias `{alias}` from FAQ `{faq_name}`")
+        else:
+            await ctx.send(f"No such FAQ `{faq_name}`")
 
     # @overrides CogGuildState
     async def on_message(self, message: Message):

--- a/commanderbot_ext/faq/faq_guild_state.py
+++ b/commanderbot_ext/faq/faq_guild_state.py
@@ -31,15 +31,15 @@ class FaqGuildState(CogGuildState[FaqOptions, FaqStore]):
         if faq_entry := await self.store.get_guild_faq(self.guild, faq_query):
             aliases_str = ", ".join(faq_entry.aliases)
             added_on_str = faq_entry.added_on.isoformat()
-            last_modified_on_str = faq_entry.last_modified_on.isoformat()
+            updated_on_str = faq_entry.updated_on.isoformat()
             lines = [
                 f"<{faq_entry.message_link}>",
                 "```",
-                f"Name:             {faq_entry.name}",
-                f"Aliases:          {aliases_str}",
-                f"Added on:         {added_on_str}",
-                f"Last modified on: {last_modified_on_str}",
-                f"Hits:             {faq_entry.hits}",
+                f"Name:       {faq_entry.name}",
+                f"Aliases:    {aliases_str}",
+                f"Added on:   {added_on_str}",
+                f"Updated on: {updated_on_str}",
+                f"Hits:       {faq_entry.hits}",
                 "```",
             ]
             content = "\n".join(lines)
@@ -58,7 +58,7 @@ class FaqGuildState(CogGuildState[FaqOptions, FaqStore]):
                 message_link=message.jump_url,
                 aliases=[],
                 added_on=now,
-                last_modified_on=now,
+                updated_on=now,
                 hits=0,
             )
             await self.store.add_guild_faq(self.guild, faq_entry)

--- a/commanderbot_ext/faq/faq_guild_state.py
+++ b/commanderbot_ext/faq/faq_guild_state.py
@@ -11,7 +11,8 @@ from discord.ext.commands import Context
 class FaqGuildState(CogGuildState[FaqOptions, FaqStore]):
     async def list_faqs(self, ctx: Context):
         if entries := await self.store.iter_guild_faqs(self.guild):
-            sorted_entries = sorted(entries, key=lambda entry: entry.name)
+            # Sort entries by hits -> name.
+            sorted_entries = sorted(entries, key=lambda entry: (entry.hits, entry.name))
             faq_names = (entry.name for entry in sorted_entries)
             text = "`" + "` `".join(faq_names) + "`"
             await ctx.send(text)

--- a/commanderbot_ext/faq/faq_guild_state.py
+++ b/commanderbot_ext/faq/faq_guild_state.py
@@ -9,16 +9,13 @@ from discord.ext.commands import Context
 
 
 class FaqGuildState(CogGuildState[FaqOptions, FaqStore]):
-    @property
-    def count_faqs(self) -> int:
-        return self.store.count_guild_faqs(self.guild) or 0
-
     async def list_faqs(self, ctx: Context):
         if entries := await self.store.iter_guild_faqs(self.guild):
             # Sort entries by hits -> name.
             sorted_entries = sorted(entries, key=lambda entry: (entry.hits, entry.name))
+            count = len(sorted_entries)
             faq_names = (entry.name for entry in sorted_entries)
-            text = "`" + "` `".join(faq_names) + "`"
+            text = f"There are {count} FAQs available: `" + "` `".join(faq_names) + "`"
             await ctx.send(text)
         else:
             await ctx.send(f"No FAQs available")

--- a/commanderbot_ext/faq/faq_guild_state.py
+++ b/commanderbot_ext/faq/faq_guild_state.py
@@ -87,7 +87,7 @@ class FaqGuildState(CogGuildState[FaqOptions, FaqStore]):
             if await self.store.remove_alias_from_faq(faq_entry, faq_alias):
                 await ctx.send(f"Removed alias `{faq_alias}` from FAQ `{faq_name}`")
             else:
-                await ctx.send(f"FAQ `{faq_name}` does not have alias {faq_alias}")
+                await ctx.send(f"FAQ `{faq_name}` has no alias `{faq_alias}`")
         else:
             await ctx.send(f"No FAQ named `{faq_name}`")
 

--- a/commanderbot_ext/faq/faq_guild_state.py
+++ b/commanderbot_ext/faq/faq_guild_state.py
@@ -74,7 +74,7 @@ class FaqGuildState(CogGuildState[FaqOptions, FaqStore]):
             await ctx.send(f"No FAQ named `{faq_name}`")
 
     async def add_alias(self, ctx: Context, faq_name: str, faq_alias: str):
-        if faq_entry := await self.store.get_guild_faq(self.guild, faq_name):
+        if faq_entry := await self.store.get_guild_faq_by_name(self.guild, faq_name):
             if await self.store.add_alias_to_faq(faq_entry, faq_alias):
                 await ctx.send(f"Added alias `{faq_alias}` to FAQ `{faq_name}`")
             else:
@@ -83,7 +83,7 @@ class FaqGuildState(CogGuildState[FaqOptions, FaqStore]):
             await ctx.send(f"No FAQ named `{faq_name}`")
 
     async def remove_alias(self, ctx: Context, faq_name: str, faq_alias: str):
-        if faq_entry := await self.store.get_guild_faq(self.guild, faq_name):
+        if faq_entry := await self.store.get_guild_faq_by_name(self.guild, faq_name):
             if await self.store.remove_alias_from_faq(faq_entry, faq_alias):
                 await ctx.send(f"Removed alias `{faq_alias}` from FAQ `{faq_name}`")
             else:

--- a/commanderbot_ext/faq/faq_migrations.py
+++ b/commanderbot_ext/faq/faq_migrations.py
@@ -1,7 +1,13 @@
+from datetime import datetime
+
 from commanderbot_lib.database.abc.versioned_file_database import VersionedFileDatabase
 
 
 async def m_1a_init_empty_aliases(database: VersionedFileDatabase, data: dict):
+    now = datetime.utcnow().isoformat()
     for guild_id, guild_data in data["guilds"].items():
         for entry_key, entry_data in guild_data["entries"].items():
             entry_data["aliases"] = []
+            entry_data["added_on"] = now
+            entry_data["last_modified_on"] = now
+            entry_data["hits"] = 0

--- a/commanderbot_ext/faq/faq_migrations.py
+++ b/commanderbot_ext/faq/faq_migrations.py
@@ -1,0 +1,7 @@
+from commanderbot_lib.database.abc.versioned_file_database import VersionedFileDatabase
+
+
+async def m_1a_init_empty_aliases(database: VersionedFileDatabase, data: dict):
+    for guild_id, guild_data in data["guilds"].items():
+        for entry_key, entry_data in guild_data["entries"].items():
+            entry_data["aliases"] = []

--- a/commanderbot_ext/faq/faq_migrations.py
+++ b/commanderbot_ext/faq/faq_migrations.py
@@ -9,5 +9,5 @@ async def m_1a_init_empty_aliases(database: VersionedFileDatabase, data: dict):
         for entry_key, entry_data in guild_data["entries"].items():
             entry_data["aliases"] = []
             entry_data["added_on"] = now
-            entry_data["last_modified_on"] = now
+            entry_data["updated_on"] = now
             entry_data["hits"] = 0

--- a/commanderbot_ext/faq/faq_migrations.py
+++ b/commanderbot_ext/faq/faq_migrations.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from commanderbot_lib.database.abc.versioned_file_database import VersionedFileDatabase
 
 
-async def m_1a_init_empty_aliases(database: VersionedFileDatabase, data: dict):
+async def m_1a_init_aliases_dates_hits(database: VersionedFileDatabase, data: dict):
     now = datetime.utcnow().isoformat()
     for guild_id, guild_data in data["guilds"].items():
         for entry_key, entry_data in guild_data["entries"].items():

--- a/commanderbot_ext/faq/faq_options.py
+++ b/commanderbot_ext/faq/faq_options.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Optional
 
 from commanderbot_lib.options.abc.cog_options import CogOptions
 
 
 @dataclass
 class FaqOptions(CogOptions):
-    database: Any = None
-    prefix: str = None
+    database: Optional[Any] = None
+    prefix: Optional[str] = None

--- a/commanderbot_ext/faq/faq_state.py
+++ b/commanderbot_ext/faq/faq_state.py
@@ -10,10 +10,6 @@ class FaqState(CogState[FaqOptions, FaqStore, FaqGuildState]):
     store_class = FaqStore
     guild_state_class = FaqGuildState
 
-    @property
-    def count_total_faqs(self) -> int:
-        return sum(guild_state.count_faqs for guild_state in self.available_guild_states)
-
     async def list_faqs(self, ctx: Context):
         if guild_state := await self.get_guild_state(ctx.guild):
             await guild_state.list_faqs(ctx)

--- a/commanderbot_ext/faq/faq_state.py
+++ b/commanderbot_ext/faq/faq_state.py
@@ -18,10 +18,22 @@ class FaqState(CogState[FaqOptions, FaqStore, FaqGuildState]):
         if guild_state := await self.get_guild_state(ctx.guild):
             await guild_state.show_faq(ctx, name)
 
-    async def add_faq(self, ctx: Context, name: str, message: Message):
+    async def show_faq_details(self, ctx: Context, name: str):
         if guild_state := await self.get_guild_state(ctx.guild):
-            await guild_state.add_faq(ctx, name, message)
+            await guild_state.show_faq_details(ctx, name)
+
+    async def add_faq(self, ctx: Context, name: str, message: Message, content: str):
+        if guild_state := await self.get_guild_state(ctx.guild):
+            await guild_state.add_faq(ctx, name, message, content)
 
     async def remove_faq(self, ctx: Context, name: str):
         if guild_state := await self.get_guild_state(ctx.guild):
             await guild_state.remove_faq(ctx, name)
+
+    async def add_alias(self, ctx: Context, faq_name: str, alias: str):
+        if guild_state := await self.get_guild_state(ctx.guild):
+            await guild_state.add_alias(ctx, faq_name, alias)
+
+    async def remove_alias(self, ctx: Context, faq_name: str, alias: str):
+        if guild_state := await self.get_guild_state(ctx.guild):
+            await guild_state.remove_alias(ctx, faq_name, alias)

--- a/commanderbot_ext/faq/faq_state.py
+++ b/commanderbot_ext/faq/faq_state.py
@@ -10,6 +10,10 @@ class FaqState(CogState[FaqOptions, FaqStore, FaqGuildState]):
     store_class = FaqStore
     guild_state_class = FaqGuildState
 
+    @property
+    def count_total_faqs(self) -> int:
+        return sum(guild_state.count_faqs for guild_state in self.available_guild_states)
+
     async def list_faqs(self, ctx: Context):
         if guild_state := await self.get_guild_state(ctx.guild):
             await guild_state.list_faqs(ctx)

--- a/commanderbot_ext/faq/faq_state.py
+++ b/commanderbot_ext/faq/faq_state.py
@@ -30,6 +30,10 @@ class FaqState(CogState[FaqOptions, FaqStore, FaqGuildState]):
         if guild_state := await self.get_guild_state(ctx.guild):
             await guild_state.remove_faq(ctx, faq_name)
 
+    async def update_faq(self, ctx: Context, faq_name: str, message: Message, content: str):
+        if guild_state := await self.get_guild_state(ctx.guild):
+            await guild_state.update_faq(ctx, faq_name, message, content)
+
     async def add_alias(self, ctx: Context, faq_name: str, alias: str):
         if guild_state := await self.get_guild_state(ctx.guild):
             await guild_state.add_alias(ctx, faq_name, alias)

--- a/commanderbot_ext/faq/faq_state.py
+++ b/commanderbot_ext/faq/faq_state.py
@@ -14,21 +14,21 @@ class FaqState(CogState[FaqOptions, FaqStore, FaqGuildState]):
         if guild_state := await self.get_guild_state(ctx.guild):
             await guild_state.list_faqs(ctx)
 
-    async def show_faq(self, ctx: Context, name: str):
+    async def show_faq(self, ctx: Context, faq_query: str):
         if guild_state := await self.get_guild_state(ctx.guild):
-            await guild_state.show_faq(ctx, name)
+            await guild_state.show_faq(ctx, faq_query)
 
-    async def show_faq_details(self, ctx: Context, name: str):
+    async def show_faq_details(self, ctx: Context, faq_query: str):
         if guild_state := await self.get_guild_state(ctx.guild):
-            await guild_state.show_faq_details(ctx, name)
+            await guild_state.show_faq_details(ctx, faq_query)
 
-    async def add_faq(self, ctx: Context, name: str, message: Message, content: str):
+    async def add_faq(self, ctx: Context, faq_name: str, message: Message, content: str):
         if guild_state := await self.get_guild_state(ctx.guild):
-            await guild_state.add_faq(ctx, name, message, content)
+            await guild_state.add_faq(ctx, faq_name, message, content)
 
-    async def remove_faq(self, ctx: Context, name: str):
+    async def remove_faq(self, ctx: Context, faq_name: str):
         if guild_state := await self.get_guild_state(ctx.guild):
-            await guild_state.remove_faq(ctx, name)
+            await guild_state.remove_faq(ctx, faq_name)
 
     async def add_alias(self, ctx: Context, faq_name: str, alias: str):
         if guild_state := await self.get_guild_state(ctx.guild):

--- a/commanderbot_ext/faq/faq_store.py
+++ b/commanderbot_ext/faq/faq_store.py
@@ -29,7 +29,7 @@ class FaqStore(VersionedCachedStore[FaqOptions, VersionedFileDatabase, FaqCache]
         expected_version: int,
     ) -> Iterable[DataMigration]:
         if actual_version < 1:
-            yield migrations.m_1a_init_empty_aliases
+            yield migrations.m_1a_init_aliases_dates_hits
 
     # @implements VersionedCachedStore
     @property

--- a/commanderbot_ext/faq/faq_store.py
+++ b/commanderbot_ext/faq/faq_store.py
@@ -46,28 +46,25 @@ class FaqStore(VersionedCachedStore[FaqOptions, VersionedFileDatabase, FaqCache]
         if guild_data := self.get_guild_data(guild):
             return guild_data.entries.values()
 
-    async def get_guild_faq_by_name(
-        self, guild_data: FaqGuildData, faq_name: str
-    ) -> Optional[FaqEntry]:
-        return guild_data.entries.get(faq_name)
+    async def get_guild_faq_by_name(self, guild: Guild, faq_name: str) -> Optional[FaqEntry]:
+        if guild_data := self.get_guild_data(guild):
+            return guild_data.entries.get(faq_name)
 
-    async def get_guild_faq_by_alias(
-        self, guild_data: FaqGuildData, faq_alias: str
-    ) -> Optional[FaqEntry]:
-        # TODO Optimize look-up by re-building a map every time aliases are changed. #optimize
-        for faq_entry in guild_data.entries.values():
-            if faq_alias in faq_entry.aliases:
-                return faq_entry
+    async def get_guild_faq_by_alias(self, guild: Guild, faq_alias: str) -> Optional[FaqEntry]:
+        if guild_data := self.get_guild_data(guild):
+            # TODO Optimize look-up by re-building a map every time aliases are changed. #optimize
+            for faq_entry in guild_data.entries.values():
+                if faq_alias in faq_entry.aliases:
+                    return faq_entry
 
     async def get_guild_faq(self, guild: Guild, faq_query: str) -> Optional[FaqEntry]:
-        if guild_data := self.get_guild_data(guild):
-            # First try to get the FAQ entry by name.
-            entry = await self.get_guild_faq_by_name(guild_data, faq_query)
-            # If that doesn't work, try to get it by alias.
-            if entry is None:
-                entry = await self.get_guild_faq_by_alias(guild_data, faq_query)
-            # Return whatever we get, even if nothing comes up.
-            return entry
+        # First try to get the FAQ entry by name.
+        entry = await self.get_guild_faq_by_name(guild, faq_query)
+        # If that doesn't work, try to get it by alias.
+        if entry is None:
+            entry = await self.get_guild_faq_by_alias(guild, faq_query)
+        # Return whatever we get, even if nothing comes up.
+        return entry
 
     async def add_guild_faq(self, guild: Guild, faq_entry: FaqEntry):
         guild_data = self.get_guild_data(guild)

--- a/commanderbot_ext/faq/faq_store.py
+++ b/commanderbot_ext/faq/faq_store.py
@@ -79,7 +79,7 @@ class FaqStore(VersionedCachedStore[FaqOptions, VersionedFileDatabase, FaqCache]
 
     async def update_faq(self, entry: FaqEntry, message: Message, content: str):
         now = datetime.utcnow()
-        entry.last_modified_on = now
+        entry.updated_on = now
         entry.content = content
         entry.message_link = message.jump_url
         await self.dirty()

--- a/commanderbot_ext/faq/faq_store.py
+++ b/commanderbot_ext/faq/faq_store.py
@@ -38,6 +38,10 @@ class FaqStore(VersionedCachedStore[FaqOptions, VersionedFileDatabase, FaqCache]
     def get_guild_data(self, guild: Guild) -> Optional[FaqGuildData]:
         return self._cache.guilds.get(guild.id)
 
+    def count_guild_faqs(self, guild: Guild) -> Optional[int]:
+        if guild_data := self.get_guild_data(guild):
+            return len(guild_data.entries)
+
     async def iter_guild_faqs(self, guild: Guild) -> Optional[Iterable[FaqEntry]]:
         if guild_data := self.get_guild_data(guild):
             return guild_data.entries.values()

--- a/commanderbot_ext/faq/faq_store.py
+++ b/commanderbot_ext/faq/faq_store.py
@@ -63,7 +63,6 @@ class FaqStore(VersionedCachedStore[FaqOptions, VersionedFileDatabase, FaqCache]
 
     async def increment_faq_hits(self, entry: FaqEntry) -> int:
         entry.hits += 1
-        # TODO This should be flushed on unload; not every access! #optimize
         await self.dirty()
         return entry.hits
 

--- a/commanderbot_ext/faq/faq_store.py
+++ b/commanderbot_ext/faq/faq_store.py
@@ -75,9 +75,9 @@ class FaqStore(VersionedCachedStore[FaqOptions, VersionedFileDatabase, FaqCache]
 
     async def remove_guild_faq(self, guild: Guild, faq_name: str) -> Optional[FaqEntry]:
         if guild_data := self.get_guild_data(guild):
-            removed_entry = guild_data.entries.pop(faq_name, None)
-            await self.dirty()
-            return removed_entry
+            if removed_entry := guild_data.entries.pop(faq_name, None):
+                await self.dirty()
+                return removed_entry
 
     async def increment_faq_hits(self, entry: FaqEntry) -> int:
         entry.hits += 1

--- a/commanderbot_ext/faq/faq_store.py
+++ b/commanderbot_ext/faq/faq_store.py
@@ -38,10 +38,6 @@ class FaqStore(VersionedCachedStore[FaqOptions, VersionedFileDatabase, FaqCache]
     def get_guild_data(self, guild: Guild) -> Optional[FaqGuildData]:
         return self._cache.guilds.get(guild.id)
 
-    def count_guild_faqs(self, guild: Guild) -> Optional[int]:
-        if guild_data := self.get_guild_data(guild):
-            return len(guild_data.entries)
-
     async def iter_guild_faqs(self, guild: Guild) -> Optional[Iterable[FaqEntry]]:
         if guild_data := self.get_guild_data(guild):
             return guild_data.entries.values()

--- a/commanderbot_ext/faq/faq_store.py
+++ b/commanderbot_ext/faq/faq_store.py
@@ -42,9 +42,16 @@ class FaqStore(VersionedCachedStore[FaqOptions, VersionedFileDatabase, FaqCache]
         if guild_data := self.get_guild_data(guild):
             return guild_data.entries.values()
 
-    async def get_guild_faq(self, guild: Guild, faq_name: str) -> Optional[FaqEntry]:
+    async def get_guild_faq(
+        self, guild: Guild, faq_name: str, hit: bool = False
+    ) -> Optional[FaqEntry]:
         if guild_data := self.get_guild_data(guild):
-            return guild_data.entries.get(faq_name)
+            entry = guild_data.entries.get(faq_name)
+            if hit and entry:
+                entry.hits += 1
+                # TODO This should be flushed on unload; not every access! #optimize
+                await self.dirty()
+            return entry
 
     async def add_guild_faq(self, guild: Guild, faq_entry: FaqEntry):
         guild_data = self.get_guild_data(guild)

--- a/commanderbot_ext/faq/faq_store.py
+++ b/commanderbot_ext/faq/faq_store.py
@@ -42,9 +42,27 @@ class FaqStore(VersionedCachedStore[FaqOptions, VersionedFileDatabase, FaqCache]
         if guild_data := self.get_guild_data(guild):
             return guild_data.entries.values()
 
+    async def get_guild_faq_by_name(
+        self, guild_data: FaqGuildData, faq_name: str
+    ) -> Optional[FaqEntry]:
+        return guild_data.entries.get(faq_name)
+
+    async def get_guild_faq_by_alias(
+        self, guild_data: FaqGuildData, faq_alias: str
+    ) -> Optional[FaqEntry]:
+        # TODO Optimize look-up by re-building a map every time aliases are changed. #optimize
+        for faq_entry in guild_data.entries.values():
+            if faq_alias in faq_entry.aliases:
+                return faq_entry
+
     async def get_guild_faq(self, guild: Guild, faq_name: str) -> Optional[FaqEntry]:
         if guild_data := self.get_guild_data(guild):
-            entry = guild_data.entries.get(faq_name)
+            # First try to get the FAQ entry by name.
+            entry = await self.get_guild_faq_by_name(guild_data, faq_name)
+            # If that doesn't work, try to get it by alias.
+            if entry is None:
+                entry = await self.get_guild_faq_by_alias(guild_data, faq_name)
+            # Return whatever we get, even if nothing comes up.
             return entry
 
     async def add_guild_faq(self, guild: Guild, faq_entry: FaqEntry):

--- a/commanderbot_ext/faq/faq_store.py
+++ b/commanderbot_ext/faq/faq_store.py
@@ -61,18 +61,22 @@ class FaqStore(VersionedCachedStore[FaqOptions, VersionedFileDatabase, FaqCache]
             await self.dirty()
             return removed_entry
 
-    async def increment_entry_hits(self, entry: FaqEntry):
+    async def increment_faq_hits(self, entry: FaqEntry) -> int:
         entry.hits += 1
         # TODO This should be flushed on unload; not every access! #optimize
         await self.dirty()
+        return entry.hits
 
-    async def add_alias_to_entry(self, entry: FaqEntry, alias: str):
-        # Adding a duplicate alias will have no effect, thanks to the power of sets.
+    async def add_alias_to_faq(self, entry: FaqEntry, alias: str) -> bool:
+        if alias in entry.aliases:
+            return False
         entry.aliases.add(alias)
         await self.dirty()
+        return True
 
-    async def remove_alias_from_entry(self, entry: FaqEntry, alias: str):
-        # Silently ignore aliases that are not present.
-        if alias in entry.aliases:
-            entry.aliases.remove(alias)
-            await self.dirty()
+    async def remove_alias_from_faq(self, entry: FaqEntry, alias: str) -> bool:
+        if alias not in entry.aliases:
+            return False
+        entry.aliases.remove(alias)
+        await self.dirty()
+        return True

--- a/commanderbot_ext/faq/faq_store.py
+++ b/commanderbot_ext/faq/faq_store.py
@@ -42,16 +42,15 @@ class FaqStore(VersionedCachedStore[FaqOptions, VersionedFileDatabase, FaqCache]
         if guild_data := self.get_guild_data(guild):
             return guild_data.entries.values()
 
-    async def get_guild_faq(
-        self, guild: Guild, faq_name: str, hit: bool = False
-    ) -> Optional[FaqEntry]:
+    async def get_guild_faq(self, guild: Guild, faq_name: str) -> Optional[FaqEntry]:
         if guild_data := self.get_guild_data(guild):
             entry = guild_data.entries.get(faq_name)
-            if hit and entry:
-                entry.hits += 1
-                # TODO This should be flushed on unload; not every access! #optimize
-                await self.dirty()
             return entry
+
+    async def hit_entry(self, entry: FaqEntry):
+        entry.hits += 1
+        # TODO This should be flushed on unload; not every access! #optimize
+        await self.dirty()
 
     async def add_guild_faq(self, guild: Guild, faq_entry: FaqEntry):
         guild_data = self.get_guild_data(guild)

--- a/commanderbot_ext/faq/faq_store.py
+++ b/commanderbot_ext/faq/faq_store.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Iterable, Optional
 
 from commanderbot_ext.faq import faq_migrations as migrations
@@ -8,7 +9,7 @@ from commanderbot_lib.database.abc.versioned_file_database import (
     VersionedFileDatabase,
 )
 from commanderbot_lib.store.abc.versioned_cached_store import VersionedCachedStore
-from discord import Guild
+from discord import Guild, Message
 
 
 class FaqStore(VersionedCachedStore[FaqOptions, VersionedFileDatabase, FaqCache]):
@@ -75,6 +76,13 @@ class FaqStore(VersionedCachedStore[FaqOptions, VersionedFileDatabase, FaqCache]
             if removed_entry := guild_data.entries.pop(faq_name, None):
                 await self.dirty()
                 return removed_entry
+
+    async def update_faq(self, entry: FaqEntry, message: Message, content: str):
+        now = datetime.utcnow()
+        entry.last_modified_on = now
+        entry.content = content
+        entry.message_link = message.jump_url
+        await self.dirty()
 
     async def increment_faq_hits(self, entry: FaqEntry) -> int:
         entry.hits += 1

--- a/commanderbot_ext/faq/faq_store.py
+++ b/commanderbot_ext/faq/faq_store.py
@@ -55,13 +55,13 @@ class FaqStore(VersionedCachedStore[FaqOptions, VersionedFileDatabase, FaqCache]
             if faq_alias in faq_entry.aliases:
                 return faq_entry
 
-    async def get_guild_faq(self, guild: Guild, faq_name: str) -> Optional[FaqEntry]:
+    async def get_guild_faq(self, guild: Guild, faq_query: str) -> Optional[FaqEntry]:
         if guild_data := self.get_guild_data(guild):
             # First try to get the FAQ entry by name.
-            entry = await self.get_guild_faq_by_name(guild_data, faq_name)
+            entry = await self.get_guild_faq_by_name(guild_data, faq_query)
             # If that doesn't work, try to get it by alias.
             if entry is None:
-                entry = await self.get_guild_faq_by_alias(guild_data, faq_name)
+                entry = await self.get_guild_faq_by_alias(guild_data, faq_query)
             # Return whatever we get, even if nothing comes up.
             return entry
 


### PR DESCRIPTION
Improving and extending `faq` has provided an opportunity to extend commanderbot-lib with generalized utilities, such as versioned data and migrations (via `VersionedCachedStore`) for seamless upgrades. Here are the changes specific to `faq` that came along with this:

  - FAQs can be created and updated directly from existing messages
  - FAQs can be assigned any number of aliases
  - FAQs remember when they were created and last updated
  - FAQs keep track of how many times they're used (hits)
  - The list of FAQs is sorted by hits -> name
  - More sub-commands for managing FAQs directly