### PR TITLE
Hide stacktraces by default and add name argument to pack command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## Changed
+
+- Optional `pack` command argument for changing the name of the generated data pack or resource pack
+- The `pack` command no longer shows exception tracebacks by default
+
 ## [0.9.0] - 2021-05-09
 
 ## Changed

--- a/commanderbot_ext/ext/pack/pack_cog.py
+++ b/commanderbot_ext/ext/pack/pack_cog.py
@@ -1,6 +1,7 @@
 import asyncio
 import io
 from logging import Logger, getLogger
+from typing import Optional
 
 from discord import File, Message
 from discord.ext.commands import Bot, Cog, Context, command
@@ -17,7 +18,7 @@ class PackCog(Cog, name="commanderbot_ext.ext.pack"):
         self.show_stacktraces = options.pop("stacktraces", False)
 
     @command(name="pack")
-    async def cmd_pack(self, ctx: Context):
+    async def cmd_pack(self, ctx: Context, name: Optional[str]):
         if not ctx.message:
             self.log.warn("Command executed without message.")
             return
@@ -36,7 +37,7 @@ class PackCog(Cog, name="commanderbot_ext.ext.pack"):
             self.project_config,
             self.build_timeout,
             self.show_stacktraces,
-            author,
+            name or author,
             message_content,
         )
 

--- a/commanderbot_ext/ext/pack/pack_cog.py
+++ b/commanderbot_ext/ext/pack/pack_cog.py
@@ -38,7 +38,7 @@ class PackCog(Cog, name="commanderbot_ext.ext.pack"):
             message_content,
         )
 
-        content = f"```{joined}```" if (joined := "\n\n".join(build_output)) else ""
+        content = f"```\n{joined}\n```" if (joined := "\n\n".join(build_output)) else ""
         files = [
             File(io.BytesIO(data), filename=filename)
             for filename, data in attachments.items()

--- a/commanderbot_ext/ext/pack/pack_cog.py
+++ b/commanderbot_ext/ext/pack/pack_cog.py
@@ -14,6 +14,7 @@ class PackCog(Cog, name="commanderbot_ext.ext.pack"):
         self.log: Logger = getLogger(self.qualified_name)
         self.project_config = options
         self.build_timeout = options.pop("timeout", 5)
+        self.show_stacktraces = options.pop("stacktraces", False)
 
     @command(name="pack")
     async def cmd_pack(self, ctx: Context):
@@ -34,6 +35,7 @@ class PackCog(Cog, name="commanderbot_ext.ext.pack"):
             generate_packs,
             self.project_config,
             self.build_timeout,
+            self.show_stacktraces,
             author,
             message_content,
         )

--- a/commanderbot_ext/ext/pack/pack_cog.py
+++ b/commanderbot_ext/ext/pack/pack_cog.py
@@ -17,7 +17,10 @@ class PackCog(Cog, name="commanderbot_ext.ext.pack"):
         self.build_timeout = options.pop("timeout", 5)
         self.show_stacktraces = options.pop("stacktraces", False)
 
-    @command(name="pack")
+    @command(
+        name="pack",
+        brief="Generate a data pack or a resource pack.",
+    )
     async def cmd_pack(self, ctx: Context, name: Optional[str]):
         if not ctx.message:
             self.log.warn("Command executed without message.")

--- a/poetry.lock
+++ b/poetry.lock
@@ -71,7 +71,7 @@ tests = ["pytest (>=4.6)", "pytest-flake8", "pytest-cov", "PyHamcrest (>=2.0.2)"
 
 [[package]]
 name = "beet"
-version = "0.22.5"
+version = "0.23.0"
 description = "The Minecraft pack development kit"
 category = "main"
 optional = false
@@ -221,14 +221,14 @@ i18n = ["Babel (>=0.8)"]
 
 [[package]]
 name = "lectern"
-version = "0.12.0"
+version = "0.13.0"
 description = "Literate Minecraft data packs and resource packs."
 category = "main"
 optional = false
 python-versions = ">=3.8,<4.0"
 
 [package.dependencies]
-beet = ">=0.22.5"
+beet = ">=0.23.0"
 click = ">=7.1.2,<8.0.0"
 markdown-it-py = ">=1.1.0,<2.0.0"
 
@@ -403,7 +403,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "5a6effd8a6490882700a2186bdae12eec367a1048ea1e463ce07b45ffa5a863b"
+content-hash = "7dbd5aba8dd41c4748c640687fc5f7a9a3ecc835a826d94005a9d8587e90f617"
 
 [metadata.files]
 aiohttp = [
@@ -466,8 +466,8 @@ base58 = [
     {file = "base58-2.1.0.tar.gz", hash = "sha256:171a547b4a3c61e1ae3807224a6f7aec75e364c4395e7562649d7335768001a2"},
 ]
 beet = [
-    {file = "beet-0.22.5-py3-none-any.whl", hash = "sha256:d181b93931fd21c5fa77f9f833d8bcfa8d8ee9e77566808cb2a928c4fff543f4"},
-    {file = "beet-0.22.5.tar.gz", hash = "sha256:928fd5393ff8e05d09b567a2e9e54f2e6e4580dd6f04650ad474e7d7c3a6af13"},
+    {file = "beet-0.23.0-py3-none-any.whl", hash = "sha256:6cacca43c1452c32b22db72f3ecb48a9ebdba820b76e7c68316af75ed9d0f8b8"},
+    {file = "beet-0.23.0.tar.gz", hash = "sha256:911ea738918616ca7974e98cc03e7e6afb2e4de9d70fdd932bfc4009b63fb945"},
 ]
 black = [
     {file = "black-20.8b1.tar.gz", hash = "sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea"},
@@ -553,8 +553,8 @@ jinja2 = [
     {file = "Jinja2-2.11.3.tar.gz", hash = "sha256:a6d58433de0ae800347cab1fa3043cebbabe8baa9d29e668f1c768cb87a333c6"},
 ]
 lectern = [
-    {file = "lectern-0.12.0-py3-none-any.whl", hash = "sha256:95e397d559cd4085cfc7078100dc4e25c0ed8ef82fef3799415f7c92c7a6b5a2"},
-    {file = "lectern-0.12.0.tar.gz", hash = "sha256:a141ca125ff938593968fe10f8c28d0258f199c0156f1836460f990f5c4a39b0"},
+    {file = "lectern-0.13.0-py3-none-any.whl", hash = "sha256:66337bc183291bef26587962d77c48b21ba3d7e8dcb95dc0da693dade24c0e7b"},
+    {file = "lectern-0.13.0.tar.gz", hash = "sha256:33686f1ce24d52ae31db04776845f53244eeef6be1d2a3aa6b7cc3ea64dd6b93"},
 ]
 markdown-it-py = [
     {file = "markdown-it-py-1.1.0.tar.gz", hash = "sha256:36be6bb3ad987bfdb839f5ba78ddf094552ca38ccbd784ae4f74a4e1419fc6e3"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -71,7 +71,7 @@ tests = ["pytest (>=4.6)", "pytest-flake8", "pytest-cov", "PyHamcrest (>=2.0.2)"
 
 [[package]]
 name = "beet"
-version = "0.22.1"
+version = "0.22.5"
 description = "The Minecraft pack development kit"
 category = "main"
 optional = false
@@ -221,35 +221,35 @@ i18n = ["Babel (>=0.8)"]
 
 [[package]]
 name = "lectern"
-version = "0.11.1"
+version = "0.12.0"
 description = "Literate Minecraft data packs and resource packs."
 category = "main"
 optional = false
 python-versions = ">=3.8,<4.0"
 
 [package.dependencies]
-beet = ">=0.22.0"
+beet = ">=0.22.5"
 click = ">=7.1.2,<8.0.0"
-markdown-it-py = ">=0.6.2,<0.7.0"
+markdown-it-py = ">=1.1.0,<2.0.0"
 
 [[package]]
 name = "markdown-it-py"
-version = "0.6.2"
+version = "1.1.0"
 description = "Python port of markdown-it. Markdown parsing, done right!"
 category = "main"
 optional = false
 python-versions = "~=3.6"
 
 [package.dependencies]
-attrs = ">=19,<21"
-mdit-py-plugins = ">=0.2.1,<0.3.0"
+attrs = ">=19,<22"
 
 [package.extras]
 code_style = ["pre-commit (==2.6)"]
-compare = ["commonmark (>=0.9.1,<0.10.0)", "markdown (>=3.2.2,<3.3.0)", "mistune (>=0.8.4,<0.9.0)", "mistletoe-ebp (>=0.10.0,<0.11.0)", "panflute (>=1.12,<2.0)"]
+compare = ["commonmark (>=0.9.1,<0.10.0)", "markdown (>=3.2.2,<3.3.0)", "mistletoe-ebp (>=0.10.0,<0.11.0)", "mistune (>=0.8.4,<0.9.0)", "panflute (>=1.12,<2.0)"]
 linkify = ["linkify-it-py (>=1.0,<2.0)"]
-rtd = ["myst-nb (>=0.11.1,<0.12.0)", "sphinx-book-theme", "sphinx-panels (>=0.4.0,<0.5.0)", "sphinx-copybutton", "sphinx (>=2,<4)", "pyyaml"]
-testing = ["coverage", "pytest (>=3.6,<4)", "pytest-cov", "pytest-regressions", "pytest-benchmark (>=3.2,<4.0)", "psutil"]
+plugins = ["mdit-py-plugins"]
+rtd = ["myst-nb (==0.13.0a1)", "pyyaml", "sphinx (>=2,<4)", "sphinx-copybutton", "sphinx-panels (>=0.4.0,<0.5.0)", "sphinx-book-theme"]
+testing = ["coverage", "psutil", "pytest (>=3.6,<4)", "pytest-benchmark (>=3.2,<4.0)", "pytest-cov", "pytest-regressions"]
 
 [[package]]
 name = "markupsafe"
@@ -258,21 +258,6 @@ description = "Safely add untrusted strings to HTML/XML markup."
 category = "main"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
-
-[[package]]
-name = "mdit-py-plugins"
-version = "0.2.6"
-description = "Collection of plugins for markdown-it-py"
-category = "main"
-optional = false
-python-versions = "~=3.6"
-
-[package.dependencies]
-markdown-it-py = ">=0.5.8,<2.0.0"
-
-[package.extras]
-code_style = ["pre-commit (==2.6)"]
-testing = ["coverage", "pytest (>=3.6,<4)", "pytest-cov", "pytest-regressions"]
 
 [[package]]
 name = "multidict"
@@ -418,7 +403,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "76379cf03719982cc03c71fc03cf5ea7e7d35f1b07298c61d0602da09d3bf5e4"
+content-hash = "5a6effd8a6490882700a2186bdae12eec367a1048ea1e463ce07b45ffa5a863b"
 
 [metadata.files]
 aiohttp = [
@@ -481,8 +466,8 @@ base58 = [
     {file = "base58-2.1.0.tar.gz", hash = "sha256:171a547b4a3c61e1ae3807224a6f7aec75e364c4395e7562649d7335768001a2"},
 ]
 beet = [
-    {file = "beet-0.22.1-py3-none-any.whl", hash = "sha256:75010a6a90c29625a5f84436266c8bee8ede774ca738e66f2d350560d8f08f55"},
-    {file = "beet-0.22.1.tar.gz", hash = "sha256:d354be21b2ebc5bee83cb686a88bedc26bbd1b7a4225fc85277232221629c785"},
+    {file = "beet-0.22.5-py3-none-any.whl", hash = "sha256:d181b93931fd21c5fa77f9f833d8bcfa8d8ee9e77566808cb2a928c4fff543f4"},
+    {file = "beet-0.22.5.tar.gz", hash = "sha256:928fd5393ff8e05d09b567a2e9e54f2e6e4580dd6f04650ad474e7d7c3a6af13"},
 ]
 black = [
     {file = "black-20.8b1.tar.gz", hash = "sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea"},
@@ -568,12 +553,12 @@ jinja2 = [
     {file = "Jinja2-2.11.3.tar.gz", hash = "sha256:a6d58433de0ae800347cab1fa3043cebbabe8baa9d29e668f1c768cb87a333c6"},
 ]
 lectern = [
-    {file = "lectern-0.11.1-py3-none-any.whl", hash = "sha256:d2db8d2769a329d0a3fe6b9b8bd5152d298959f3391a18c0b37d6f412a3e894d"},
-    {file = "lectern-0.11.1.tar.gz", hash = "sha256:ad7d4463f92a2c42577bcad2249251d461bd2a0ed9cd876213d6ff0e28ff9b75"},
+    {file = "lectern-0.12.0-py3-none-any.whl", hash = "sha256:95e397d559cd4085cfc7078100dc4e25c0ed8ef82fef3799415f7c92c7a6b5a2"},
+    {file = "lectern-0.12.0.tar.gz", hash = "sha256:a141ca125ff938593968fe10f8c28d0258f199c0156f1836460f990f5c4a39b0"},
 ]
 markdown-it-py = [
-    {file = "markdown-it-py-0.6.2.tar.gz", hash = "sha256:c3b9f995be0792cbbc8ab2f53d74072eb7ff8a8b622be8d61d38ab879709eca3"},
-    {file = "markdown_it_py-0.6.2-py3-none-any.whl", hash = "sha256:30b3e9f8198dc82a5df0dcb73fd31d56cd9a43bf8a747feb10b2ba74f962bcb1"},
+    {file = "markdown-it-py-1.1.0.tar.gz", hash = "sha256:36be6bb3ad987bfdb839f5ba78ddf094552ca38ccbd784ae4f74a4e1419fc6e3"},
+    {file = "markdown_it_py-1.1.0-py3-none-any.whl", hash = "sha256:98080fc0bc34c4f2bcf0846a096a9429acbd9d5d8e67ed34026c03c61c464389"},
 ]
 markupsafe = [
     {file = "MarkupSafe-1.1.1-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161"},
@@ -628,10 +613,6 @@ markupsafe = [
     {file = "MarkupSafe-1.1.1-cp39-cp39-win32.whl", hash = "sha256:22c178a091fc6630d0d045bdb5992d2dfe14e3259760e713c490da5323866c39"},
     {file = "MarkupSafe-1.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:b7d644ddb4dbd407d31ffb699f1d140bc35478da613b441c582aeb7c43838dd8"},
     {file = "MarkupSafe-1.1.1.tar.gz", hash = "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"},
-]
-mdit-py-plugins = [
-    {file = "mdit-py-plugins-0.2.6.tar.gz", hash = "sha256:1e467ca2ea056e8065cbd5d6c61e5052bb50826bde84c40f6a5ed77e82125710"},
-    {file = "mdit_py_plugins-0.2.6-py3-none-any.whl", hash = "sha256:77fd75dad81109ee91f30eb49146196f79afbbae041f298ae4886c8c2b5e23d7"},
 ]
 multidict = [
     {file = "multidict-5.1.0-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:b7993704f1a4b204e71debe6095150d43b2ee6150fa4f44d6d966ec356a8d61f"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,8 @@ python = "^3.8"
 commanderbot = "^0.7.0"
 SQLAlchemy = "^1.4.9"
 aiosqlite = "^0.17.0"
-lectern = ">=0.12.0"
-beet = ">=0.22.5"
+lectern = ">=0.13.0"
+beet = ">=0.23.0"
 
 [tool.poetry.dev-dependencies]
 black = "^20.8b1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,8 @@ python = "^3.8"
 commanderbot = "^0.7.0"
 SQLAlchemy = "^1.4.9"
 aiosqlite = "^0.17.0"
-lectern = ">=0.11.1"
-beet = ">=0.22.1"
+lectern = ">=0.12.0"
+beet = ">=0.22.5"
 
 [tool.poetry.dev-dependencies]
 black = "^20.8b1"


### PR DESCRIPTION
This fixes #30. This PR requires you to enable the `stacktraces` option to see exception tracebacks like before. Now, the default behavior is to only display the type of the exception and the single line error message for a small selection of exceptions that shouldn't contain any sensitive information.

![image](https://user-images.githubusercontent.com/24430071/117587433-39b17b00-b11e-11eb-9cb4-0710c761cd7d.png)

Also now if you type `.pack some_name` the resulting data pack will use the specified name instead of the username of the message author.

This PR also comes with some notable `beet` and `lectern` updates:

- `beet` now exposes a `parse_json()` utility function in the template environment
- the `@require` directive has been extracted into `lectern.contrib.require` and is not enabled by default anymore
- new `lectern.contrib.define` plugin that adds the `@define` directive (uses Jinja so only safe when the sandbox is active)
- new `lectern.contrib.script` plugin that adds the `@script` directive (uses Jinja so only safe when the sandbox is active)

More information about the lectern directives can be found in [the lectern readme](https://github.com/mcbeet/lectern#extra-directives).