### PR TITLE
Don't use the cache for lectern to only handle downloads in-memory

### DIFF
--- a/commanderbot_ext/ext/pack/pack_generate.py
+++ b/commanderbot_ext/ext/pack/pack_generate.py
@@ -129,4 +129,5 @@ def worker(
 
 def beet_default(ctx: Context):
     document = ctx.inject(Document)
+    document.cache = None
     document.add_markdown(ctx.meta["source"])


### PR DESCRIPTION
Turns out the little discussion about downloading files being unsafe stuck and I realized that I was wrong and that currently downloading files does save them in a temporary directory that's discarded at the end of the build. This is because beet needs a cache and when you use `run_beet` without providing a cache directory it creates its own [temporary directory](https://docs.python.org/3/library/tempfile.html#tempfile.TemporaryDirectory). When lectern is used within a beet pipeline it grabs the cache and uses it to [cache downloads](https://github.com/mcbeet/lectern#beet-plugin). This is desirable most of the time but in this particular case for the bot it's not really what we want.

Now by setting the cache to None the downloads don't get saved in a temporary directory anymore. There are no longer any filesystem operations involved when letting lectern download things and everything happens in memory.